### PR TITLE
Add AHCAL sensitive detector

### DIFF
--- a/include/HGCALTBAHCALSD.hh
+++ b/include/HGCALTBAHCALSD.hh
@@ -15,7 +15,7 @@
 
 // Includers form project files
 //
-// #  include "HGCALTBCAHCALHit.hh"
+#  include "HGCALTBAHHit.hh"
 #  include "HGCALTBConstants.hh"
 
 #  define DEBUGAHCALSD
@@ -42,7 +42,7 @@ class HGCALTBAHCALSD : public G4VSensitiveDetector
     static const G4String fAHCALHitsCollectionName;
 
   private:
-    // HGCALTBAHCALHitsCollection* fHitsCollection;
+    HGCALTBAHCALHitsCollection* fHitsCollection;
     inline G4int MapTileCpNo(G4int cpno) const;
 };
 

--- a/include/HGCALTBAHCALSD.hh
+++ b/include/HGCALTBAHCALSD.hh
@@ -18,7 +18,7 @@
 #  include "HGCALTBAHHit.hh"
 #  include "HGCALTBConstants.hh"
 
-#  define DEBUGAHCALSD
+// #  define DEBUGAHCALSD
 
 // Forward declaration from Geant4
 //
@@ -66,7 +66,7 @@ inline G4int HGCALTBAHCALSD::MapTileCpNo(G4int cpno) const
   .
   101201..101212
 
-  quadrant 4 (up-left):
+  quadrant 4 (down-left):
   110101..110112
   .
   .
@@ -107,7 +107,7 @@ inline G4int HGCALTBAHCALSD::MapTileCpNo(G4int cpno) const
 
   // Find column (1..12)
   G4int column = 99;
-  column = cpno - row * 100;
+  column = cpno - (row + 1) * 100;
   if (column < 1 || row > HGCALTBConstants::AHCALcolumn / 2) {
     G4ExceptionDescription msg;
     msg << "Wrong AHCAL column in quadrant 1:" << column;
@@ -127,7 +127,7 @@ inline G4int HGCALTBAHCALSD::MapTileCpNo(G4int cpno) const
 
 #  ifdef DEBUGAHCALSD
   G4cout << "cpno " << cpno << " quadrant " << quadrant << " column " << column << " row " << row
-         << G4endl;
+         << " newcpno " << newcpno << G4endl;
 #  endif
 
   return newcpno;

--- a/include/HGCALTBAHCALSD.hh
+++ b/include/HGCALTBAHCALSD.hh
@@ -1,0 +1,138 @@
+//**************************************************
+// \file HGCALTBAHCAL.hh
+// \brief: definition of HGCALTBAHCAL class
+// \author: Lorenzo Pezzotti (CERN EP-SFT-sim)
+//          @lopezzot
+// \start date: 14 January 2024
+//**************************************************
+
+#ifndef HGCALTBAHCALSD_h
+#  define HGCALTAHCALSD_h 1
+
+// Includers from Geant4
+//
+#  include "G4VSensitiveDetector.hh"
+
+// Includers form project files
+//
+// #  include "HGCALTBCAHCALHit.hh"
+#  include "HGCALTBConstants.hh"
+
+#  define DEBUGAHCALSD
+
+// Forward declaration from Geant4
+//
+class G4Step;
+class G4HCofThisEvent;
+
+class HGCALTBAHCALSD : public G4VSensitiveDetector
+{
+  public:
+    HGCALTBAHCALSD(const G4String& name);
+    virtual ~HGCALTBAHCALSD();
+
+    // virtual methods from base class
+    //
+    virtual void Initialize(G4HCofThisEvent* hitCollection);
+    virtual G4bool ProcessHits(G4Step* aStep, G4TouchableHistory* history);
+    virtual void EndOfEvent(G4HCofThisEvent* hitCollection);
+
+    // This sensitive detector creates 1 hit collection
+    //
+    static const G4String fAHCALHitsCollectionName;
+
+  private:
+    // HGCALTBAHCALHitsCollection* fHitsCollection;
+    inline G4int MapTileCpNo(G4int cpno) const;
+};
+
+inline G4int HGCALTBAHCALSD::MapTileCpNo(G4int cpno) const
+{
+  /*quadrant 1 (up-right):
+  101..112
+  .
+  .
+  1201..1212
+
+  quadrant 2 (up-left):
+  10101..10112
+  .
+  .
+  11201..11212
+
+  quadrant 3 (down-right):
+  100101..100112
+  .
+  .
+  101201..101212
+
+  quadrant 4 (up-left):
+  110101..110112
+  .
+  .
+  111201..111212*/
+
+  // Find quadrant
+  G4int quadrant = 0;
+  if (cpno <= 1212)
+    quadrant = 1;
+  else if (cpno > 1212 && cpno <= 11212)
+    quadrant = 2;
+  else if (cpno > 11212 && cpno <= 101212)
+    quadrant = 3;
+  else if (cpno > 101212 && cpno <= 111212)
+    quadrant = 4;
+  else {
+    G4ExceptionDescription msg;
+    msg << "Wrong AHCAL cpno" << cpno;
+    G4Exception("HGCALTBAHCALSD::MapTileCpNo", "MyCode0004", FatalException, msg);
+  }
+
+  if (quadrant == 2)
+    cpno = cpno - 10000;
+  else if (quadrant == 3)
+    cpno = cpno - 100000;
+  else if (quadrant == 4)
+    cpno = cpno - 110000;
+
+  // Find row (1...12)
+  G4int row = 99;
+  row = cpno / 100;
+  if (row < 1 || row > HGCALTBConstants::AHCALrow / 2) {
+    G4ExceptionDescription msg;
+    msg << "Wrong AHCAL row in quadrant 1:" << row;
+    G4Exception("HGCALTBAHCALSD::MapTileCpNo", "MyCode0004", FatalException, msg);
+  }
+  row = row - 1;  // make row number start from 0
+
+  // Find column (1..12)
+  G4int column = 99;
+  column = cpno - row * 100;
+  if (column < 1 || row > HGCALTBConstants::AHCALcolumn / 2) {
+    G4ExceptionDescription msg;
+    msg << "Wrong AHCAL column in quadrant 1:" << column;
+    G4Exception("HGCALTBAHCALSD::MapTileCpNo", "MyCode0004", FatalException, msg);
+  }
+  column = column - 1;  // make column number start from 0
+
+  // Construct final cpno from 0 to 575 (24x24 tiles per layer)
+  quadrant = quadrant - 1;  // make quadrant number start from 0
+  G4int newcpno = row + column * HGCALTBConstants::AHCALrow / 2
+                  + quadrant * HGCALTBConstants::AHCALtileperlayer / 4;
+  if (newcpno >= HGCALTBConstants::AHCALtileperlayer) {
+    G4ExceptionDescription msg;
+    msg << "Wrong AHCAL newcpno: " << newcpno;
+    G4Exception("HGCALTBAHCALSD::MapTileCpNo", "MyCode0004", FatalException, msg);
+  }
+
+#  ifdef DEBUGAHCALSD
+  G4cout << "cpno " << cpno << " quadrant " << quadrant << " column " << column << " row " << row
+         << G4endl;
+#  endif
+
+  return newcpno;
+}
+
+#endif  // HGCALTBAHCALSD_h 1
+
+//**************************************************

--- a/include/HGCALTBAHHit.hh
+++ b/include/HGCALTBAHHit.hh
@@ -1,0 +1,64 @@
+//**************************************************
+// \file HGCALTBAHHit.hh
+// \brief: definition of HGCALTBAHHit class
+// \author: Lorenzo Pezzotti (CERN EP-SFT-sim)
+//          @lopezzot
+// \start date: 14 January 2024
+//**************************************************
+
+#ifndef HGCALTBAHHit_h
+#  define HGCALTBAHHit_h 1
+
+// Includers from project files
+//
+#  include "HGCALTBConstants.hh"
+
+// Includers from Geant4
+//
+#  include "G4THitsCollection.hh"
+#  include "G4VHit.hh"
+
+// Includers from C++
+//
+#  include <array>
+
+class HGCALTBAHHit : public G4VHit
+{
+  public:
+    HGCALTBAHHit();
+    HGCALTBAHHit(const HGCALTBAHHit&);
+    virtual ~HGCALTBAHHit();
+
+    // Operators (= and ==)
+    //
+    const HGCALTBAHHit& operator=(const HGCALTBAHHit&);
+    G4bool operator==(const HGCALTBAHHit&) const;
+
+    // virtual methods from base class
+    //
+    virtual void Draw() {}
+    virtual void Print(){};
+
+    void AddTileEdep(G4int TileID, G4double Edep);
+
+    // return a copy of the fCEESignals array
+    //
+    std::array<G4double, HGCALTBConstants::AHCALtileperlayer> GetAHSignals() const
+    {
+      return fAHSignals;
+    }
+
+  private:
+    std::array<G4double, HGCALTBConstants::AHCALtileperlayer> fAHSignals;
+};
+
+using HGCALTBAHCALHitsCollection = G4THitsCollection<HGCALTBAHHit>;
+
+inline void HGCALTBAHHit::AddTileEdep(G4int TileID, G4double Edep)
+{
+  fAHSignals[TileID] += Edep;
+}
+
+#endif  // HGCALTBAHHit_h 1
+
+//**************************************************

--- a/include/HGCALTBConstants.hh
+++ b/include/HGCALTBConstants.hh
@@ -56,7 +56,12 @@ constexpr G4int CHECells = CHEHexLayer * (CHECellMaxCpNo - CHECellMinCpNo);  // 
 // AHCAL row and column plastic tiles
 constexpr G4int AHCALrow = 24;
 constexpr G4int AHCALcolumn = 24;
+
+// AHCAL tiles per layer
 constexpr G4int AHCALtileperlayer = AHCALrow * AHCALcolumn;
+
+// AHCAL layers
+constexpr G4int AHCALLayers = 39;
 
 // MIP calibration
 //

--- a/include/HGCALTBConstants.hh
+++ b/include/HGCALTBConstants.hh
@@ -34,7 +34,7 @@ constexpr G4int CEECellMaxCpNo = 2129;
 // CEE (small) silicon cells per big hexagon (layer)
 constexpr G4int CEECells = CEECellMaxCpNo - CEECellMinCpNo;  // 126
 
-// HGCALCHE
+// HGCALCHE constants
 //
 
 // CHE longitudinal layers
@@ -49,6 +49,14 @@ constexpr G4int CHEHexLayer = 7;
 
 // CHE (small) silicon cells per big hexagon (layer)
 constexpr G4int CHECells = CHEHexLayer * (CHECellMaxCpNo - CHECellMinCpNo);  // 7*126=882
+
+// AHCAL constants
+//
+
+// AHCAL row and column plastic tiles
+constexpr G4int AHCALrow = 24;
+constexpr G4int AHCALcolumn = 24;
+constexpr G4int AHCALtileperlayer = AHCALrow * AHCALcolumn;
 
 // MIP calibration
 //

--- a/src/HGCALTBAHCALSD.cc
+++ b/src/HGCALTBAHCALSD.cc
@@ -1,0 +1,94 @@
+//**************************************************
+// \file HGCALTBAHCALSD.cc
+// \brief: implementation of HGCALTBAHCALSD
+//         class
+// \author: Lorenzo Pezzotti (CERN EP-SFT-sim)
+//          @lopezzot
+// \start date: 14 January 2024
+//**************************************************
+
+// Includers from project files
+//
+#include "HGCALTBAHCALSD.hh"
+
+// Includers from Geant4
+//
+#include "G4HCofThisEvent.hh"
+#include "G4Poisson.hh"
+#include "G4SDManager.hh"
+#include "G4Step.hh"
+#include "G4SystemOfUnits.hh"
+#include "G4ThreeVector.hh"
+#include "G4ios.hh"
+
+const G4String HGCALTBAHCALSD::fAHCALHitsCollectionName = "AHCALHitsCollectionName";
+
+// Constructor and de-constructor
+//
+HGCALTBAHCALSD::HGCALTBAHCALSD(const G4String& name)
+  : G4VSensitiveDetector(name) /*,
+     fHitsCollection(nullptr),*/
+{
+  collectionName.insert(fAHCALHitsCollectionName);
+}
+
+HGCALTBAHCALSD::~HGCALTBAHCALSD() {}
+
+// Intiliaze virtual base method
+//
+void HGCALTBAHCALSD::Initialize(G4HCofThisEvent* hce)
+{
+  // Create hits collection
+  //
+  /*fHitsCollection = new HGCALTBCHEHitsCollection(SensitiveDetectorName, collectionName[0]);
+
+  // Add this collection in the hits collection of this event
+  //
+  auto hcID = G4SDManager::GetSDMpointer()->GetCollectionID(collectionName[0]);
+  hce->AddHitsCollection(hcID, fHitsCollection);
+
+  // Allocate hits in hit collection
+  //
+  for (G4int i = 0; i < HGCALTBConstants::CHELayers; i++) {
+    fHitsCollection->insert(new HGCALTBCHEHit());
+  }*/
+}
+
+// ProcessHits virtual base method
+//
+G4bool HGCALTBAHCALSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
+{
+  /*  // Get CHE layer ID
+    //
+    auto CHELayerID = (aStep->GetPreStepPoint()->GetTouchableHandle()->GetCopyNumber(2) - 1) / 3;
+    if (CHELayerID > HGCALTBConstants::CHELayers || CHELayerID < 0) {
+      G4ExceptionDescription msg;
+      msg << "CHE layer copy number greater than " << HGCALTBConstants::CHELayers << " or < 0";
+      G4Exception("HGCALTBCHESD::ProcessHits()", "MyCode0004", FatalException, msg);
+    }
+
+    // Get CHE silicon wafer ID (0...6)
+    //
+    auto WaferID = FindWaferID(aStep->GetPreStepPoint()->GetTouchableHandle()->GetCopyNumber(1));
+
+    // Access the corresponding hit
+    //
+    auto CellID = (aStep->GetPreStepPoint()->GetTouchableHandle()->GetCopyNumber(0)
+                   - HGCALTBConstants::CHECellMinCpNo)
+                  + (WaferID * HGCALTBConstants::CEECells);
+    if (CellID > HGCALTBConstants::CHECells || CellID < 0) {
+      G4ExceptionDescription msg;
+      msg << "CHE cell copy number greater than " << HGCALTBConstants::CHECells << "or < 0";
+      G4Exception("HGCALTBCHESD::ProcessHits()", "MyCode0004", FatalException, msg);
+    }
+    auto hit = (*fHitsCollection)[CHELayerID];
+    hit->AddCellEdep(CellID, aStep->GetTotalEnergyDeposit());
+  */
+  return true;
+}
+
+// EndOfEvent virtual base method
+//
+void HGCALTBAHCALSD::EndOfEvent(G4HCofThisEvent*) {}
+
+//**************************************************

--- a/src/HGCALTBAHCALSD.cc
+++ b/src/HGCALTBAHCALSD.cc
@@ -39,7 +39,7 @@ void HGCALTBAHCALSD::Initialize(G4HCofThisEvent* hce)
 {
   // Create hits collection
   //
-  /*fHitsCollection = new HGCALTBCHEHitsCollection(SensitiveDetectorName, collectionName[0]);
+  fHitsCollection = new HGCALTBAHCALHitsCollection(SensitiveDetectorName, collectionName[0]);
 
   // Add this collection in the hits collection of this event
   //
@@ -48,41 +48,34 @@ void HGCALTBAHCALSD::Initialize(G4HCofThisEvent* hce)
 
   // Allocate hits in hit collection
   //
-  for (G4int i = 0; i < HGCALTBConstants::CHELayers; i++) {
-    fHitsCollection->insert(new HGCALTBCHEHit());
-  }*/
+  for (G4int i = 0; i < HGCALTBConstants::AHCALLayers; i++) {
+    fHitsCollection->insert(new HGCALTBAHHit());
+  }
 }
 
 // ProcessHits virtual base method
 //
 G4bool HGCALTBAHCALSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
 {
-  /*  // Get CHE layer ID
-    //
-    auto CHELayerID = (aStep->GetPreStepPoint()->GetTouchableHandle()->GetCopyNumber(2) - 1) / 3;
-    if (CHELayerID > HGCALTBConstants::CHELayers || CHELayerID < 0) {
-      G4ExceptionDescription msg;
-      msg << "CHE layer copy number greater than " << HGCALTBConstants::CHELayers << " or < 0";
-      G4Exception("HGCALTBCHESD::ProcessHits()", "MyCode0004", FatalException, msg);
-    }
+  // Get CHE layer ID
+  //
+  auto AHCALLayerID = aStep->GetPreStepPoint()->GetTouchableHandle()->GetCopyNumber(1) - 1;
+  if (AHCALLayerID >= HGCALTBConstants::AHCALLayers || AHCALLayerID < 0) {
+    G4ExceptionDescription msg;
+    msg << "AHCAL layer copy number equal or greater than " << HGCALTBConstants::AHCALLayers
+        << " or < 0";
+    G4Exception("HGCALTBAHCALSD::ProcessHits()", "MyCode0004", FatalException, msg);
+  }
 
-    // Get CHE silicon wafer ID (0...6)
-    //
-    auto WaferID = FindWaferID(aStep->GetPreStepPoint()->GetTouchableHandle()->GetCopyNumber(1));
+  // Get tile ID
+  //
+  auto TileID = MapTileCpNo(aStep->GetPreStepPoint()->GetTouchableHandle()->GetCopyNumber(0));
 
-    // Access the corresponding hit
-    //
-    auto CellID = (aStep->GetPreStepPoint()->GetTouchableHandle()->GetCopyNumber(0)
-                   - HGCALTBConstants::CHECellMinCpNo)
-                  + (WaferID * HGCALTBConstants::CEECells);
-    if (CellID > HGCALTBConstants::CHECells || CellID < 0) {
-      G4ExceptionDescription msg;
-      msg << "CHE cell copy number greater than " << HGCALTBConstants::CHECells << "or < 0";
-      G4Exception("HGCALTBCHESD::ProcessHits()", "MyCode0004", FatalException, msg);
-    }
-    auto hit = (*fHitsCollection)[CHELayerID];
-    hit->AddCellEdep(CellID, aStep->GetTotalEnergyDeposit());
-  */
+  // Access the corresponding hit
+  //
+  auto hit = (*fHitsCollection)[AHCALLayerID];
+  hit->AddTileEdep(TileID, aStep->GetTotalEnergyDeposit());
+
   return true;
 }
 

--- a/src/HGCALTBAHCALSD.cc
+++ b/src/HGCALTBAHCALSD.cc
@@ -26,8 +26,7 @@ const G4String HGCALTBAHCALSD::fAHCALHitsCollectionName = "AHCALHitsCollectionNa
 // Constructor and de-constructor
 //
 HGCALTBAHCALSD::HGCALTBAHCALSD(const G4String& name)
-  : G4VSensitiveDetector(name) /*,
-     fHitsCollection(nullptr),*/
+  : G4VSensitiveDetector(name), fHitsCollection(nullptr)
 {
   collectionName.insert(fAHCALHitsCollectionName);
 }

--- a/src/HGCALTBAHHit.cc
+++ b/src/HGCALTBAHHit.cc
@@ -1,0 +1,43 @@
+//**************************************************
+// \file HGCALTBAHHit.cc
+// \brief: implementation of HGCALTBAHHit class
+// \author: Lorenzo Pezzotti (CERN EP-SFT-sim)
+//          @lopezzot
+// \start date: 14 January 2024
+//**************************************************
+
+// Includers from project files
+//
+#include "HGCALTBAHHit.hh"
+
+// Includers from Geant4
+#include "G4UnitsTable.hh"
+
+// Constructor and de-constructor
+//
+HGCALTBAHHit::HGCALTBAHHit() : G4VHit(), fAHSignals({}) {}
+
+HGCALTBAHHit::~HGCALTBAHHit() {}
+
+HGCALTBAHHit::HGCALTBAHHit(const HGCALTBAHHit& right) : G4VHit()
+{
+  fAHSignals = right.fAHSignals;
+}
+
+// Operator = definition
+//
+const HGCALTBAHHit& HGCALTBAHHit::operator=(const HGCALTBAHHit& right)
+{
+  fAHSignals = right.fAHSignals;
+
+  return *this;
+}
+
+// Operator == definition
+//
+G4bool HGCALTBAHHit::operator==(const HGCALTBAHHit& right) const
+{
+  return (this == &right) ? true : false;
+}
+
+//**************************************************

--- a/src/HGCALTBDetConstruction.cc
+++ b/src/HGCALTBDetConstruction.cc
@@ -11,6 +11,7 @@
 //
 #include "HGCALTBDetConstruction.hh"
 
+#include "HGCALTBAHCALSD.hh"
 #include "HGCALTBCEESD.hh"
 #include "HGCALTBCHESD.hh"
 
@@ -51,6 +52,8 @@ void HGCALTBDetConstruction::ConstructSDandField()
   G4SDManager::GetSDMpointer()->AddNewDetector(CEESD);
   auto CHESD = new HGCALTBCHESD("CHESD");
   G4SDManager::GetSDMpointer()->AddNewDetector(CHESD);
+  auto AHCALSD = new HGCALTBAHCALSD("AHSD");
+  G4SDManager::GetSDMpointer()->AddNewDetector(AHCALSD);
 
   // Assign to logical volume
   //
@@ -63,6 +66,10 @@ void HGCALTBDetConstruction::ConstructSDandField()
     if (volume->GetName() == "HGCalHECellCoarse") {
       G4cout << "--->Assigning HGCALTBCHESD to logical volume " << volume->GetName() << G4endl;
       volume->SetSensitiveDetector(CHESD);
+    }
+    if (volume->GetName() == "AHcalTileSensitive") {
+      G4cout << "--->Assigning HGCALTBAHCALSD to logical volume " << volume->GetName() << G4endl;
+      volume->SetSensitiveDetector(AHCALSD);
     }
   }
 


### PR DESCRIPTION
Add sensitive detector code for AHCAL section. Add a mapping function to utilize the sensitive tile copy number. One hit is created per each AHCAL layer, each hit contains an array with each entry corresponding to an individual plastic tile. Fill the array incrementally in the ProcessHit function.