### PR TITLE
Save AHCAL signals

### DIFF
--- a/analysis/calibration.C
+++ b/analysis/calibration.C
@@ -1,7 +1,7 @@
-// Simple macro card to plot the cell energy per layer in CEE and CHE.
+// Simple macro card to plot the cell energy per layer in CEE, CHE and AHCAL.
 // Can be used with 200 GeV mu- data to study the MIP calibration,
 // either with raw data (MeV in silicon cells) or calibrated data
-//(MIP in silicon cells).
+//(MIP in silicon cells/plastic tiles).
 void calibration()
 {
   const string filename = "HGCALTBout_Run0.root";
@@ -12,23 +12,30 @@ void calibration()
   tree->SetBranchAddress("CEETot", &CEETot);
   double CHETot{0.};
   tree->SetBranchAddress("CHETot", &CHETot);
+  double AHCALTot{0.};
+  tree->SetBranchAddress("AHCALTot", &AHCALTot);
   vector<double>* CEESignals = NULL;
   tree->SetBranchAddress("CEESignals", &CEESignals);
   vector<double>* CHESignals = NULL;
   tree->SetBranchAddress("CHESignals", &CHESignals);
+  vector<double>* AHCALSignals = NULL;
+  tree->SetBranchAddress("AHCALSignals", &AHCALSignals);
 
   TH1F H1CEE24("H1CEE24", "H1CEE24", 500, 0., 5);
   TH1F H1CHE4("H1CHE4", "H1CHE4", 500, 0., 5);
+  TH1F H1AHCAL10("H1AHCAL10", "H1AHCAL10", 500, 0., 5);
 
   for (std::size_t evtNo = 0; evtNo < tree->GetEntries(); evtNo++) {
     tree->GetEntry(evtNo);
 
     H1CEE24.Fill(CEESignals->at(24));
     H1CHE4.Fill(CHESignals->at(4));
+    H1AHCAL10.Fill(AHCALSignals->at(10));
   }
 
   TFile* outputfile(TFile::Open("HGCALTBcalib.root", "RECREATE"));
   H1CEE24.Write();
   H1CHE4.Write();
+  H1AHCAL10.Write();
   outputfile->Close();
 }

--- a/include/HGCALTBConstants.hh
+++ b/include/HGCALTBConstants.hh
@@ -63,6 +63,9 @@ constexpr G4int AHCALtileperlayer = AHCALrow * AHCALcolumn;
 // AHCAL layers
 constexpr G4int AHCALLayers = 39;
 
+// AHCAL MIP threshold
+constexpr G4double AHCALThreshold = 0.5;
+
 // MIP calibration
 //
 constexpr G4double MIPSilicon = 0.085;  // MeV

--- a/include/HGCALTBConstants.hh
+++ b/include/HGCALTBConstants.hh
@@ -66,6 +66,7 @@ constexpr G4int AHCALLayers = 39;
 // MIP calibration
 //
 constexpr G4double MIPSilicon = 0.085;  // MeV
+constexpr G4double MIPTile = 0.475;  // MeV
 
 }  // namespace HGCALTBConstants
 

--- a/include/HGCALTBEventAction.hh
+++ b/include/HGCALTBEventAction.hh
@@ -20,6 +20,7 @@
 
 // Includers from project files
 //
+#  include "HGCALTBAHHit.hh"
 #  include "HGCALTBCEEHit.hh"
 #  include "HGCALTBCHEHit.hh"
 #  include "HGCALTBConstants.hh"
@@ -37,13 +38,16 @@ class HGCALTBEventAction : public G4UserEventAction
     void Addedep(G4double stepedep);
     std::vector<G4double>& GetCEESignals() { return fCEELayerSignals; };
     std::vector<G4double>& GetCHESignals() { return fCHELayerSignals; };
+    std::vector<G4double>& GetAHCALSignals() { return fAHCALLayerSignals; };
 
   private:
     HGCALTBCEEHitsCollection* GetCEEHitsCollection(G4int hcID, const G4Event* event) const;
     HGCALTBCHEHitsCollection* GetCHEHitsCollection(G4int hcID, const G4Event* event) const;
+    HGCALTBAHCALHitsCollection* GetAHCALHitsCollection(G4int hcID, const G4Event* event) const;
     G4double edep;  // energy deposited in every volume
     std::vector<G4double> fCEELayerSignals;  // signals per CEE layer
     std::vector<G4double> fCHELayerSignals;  // signals per CHE layer
+    std::vector<G4double> fAHCALLayerSignals;  // signals per AHCAL layer
 };
 
 inline void HGCALTBEventAction::Addedep(G4double stepedep)

--- a/src/HGCALTBEventAction.cc
+++ b/src/HGCALTBEventAction.cc
@@ -153,7 +153,7 @@ void HGCALTBEventAction::EndOfEventAction(const G4Event* event)
   auto ApplyAHCut = [MIPTile = HGCALTBConstants::MIPTile,
                      AHThreshold = HGCALTBConstants::AHCALThreshold](G4double partialsum,
                                                                      G4double signal) -> G4double {
-    auto calibsignal = signal * MIPTile;
+    auto calibsignal = signal / MIPTile;
     if (calibsignal > AHThreshold)
       return partialsum + calibsignal;
     else

--- a/src/HGCALTBEventAction.cc
+++ b/src/HGCALTBEventAction.cc
@@ -152,7 +152,7 @@ void HGCALTBEventAction::EndOfEventAction(const G4Event* event)
   for (std::size_t i = 0; i < HGCALTBConstants::AHCALLayers; i++) {
     auto AHCALSignals = (*AHCALHC)[i]->GetAHSignals();
     G4double AHCALLayerSignal = std::accumulate(AHCALSignals.begin(), AHCALSignals.end(), 0.);
-    fAHCALLayerSignals[i] = AHCALLayerSignal / HGCALTBConstants::MIPSilicon;  // MIP calibration
+    fAHCALLayerSignals[i] = AHCALLayerSignal / HGCALTBConstants::MIPTile;  // MIP calibration
   }
 
   // Accumulate statistics

--- a/src/HGCALTBEventAction.cc
+++ b/src/HGCALTBEventAction.cc
@@ -11,6 +11,7 @@
 //
 #include "HGCALTBEventAction.hh"
 
+#include "HGCALTBAHCALSD.hh"
 #include "HGCALTBCEESD.hh"
 #include "HGCALTBCHESD.hh"
 #include "HGCALTBRunAction.hh"
@@ -38,6 +39,7 @@ HGCALTBEventAction::HGCALTBEventAction() : G4UserEventAction(), edep(0.)
 {
   fCEELayerSignals = std::vector<G4double>(HGCALTBConstants::CEELayers, 0.);
   fCHELayerSignals = std::vector<G4double>(HGCALTBConstants::CHELayers, 0.);
+  fAHCALLayerSignals = std::vector<G4double>(HGCALTBConstants::AHCALLayers, 0.);
 }
 
 HGCALTBEventAction::~HGCALTBEventAction() {}
@@ -53,6 +55,9 @@ void HGCALTBEventAction::BeginOfEventAction(const G4Event*)
     value = 0.;
   }
   for (auto& value : fCHELayerSignals) {
+    value = 0.;
+  }
+  for (auto& value : fAHCALLayerSignals) {
     value = 0.;
   }
 }
@@ -91,6 +96,23 @@ HGCALTBCHEHitsCollection* HGCALTBEventAction::GetCHEHitsCollection(G4int hcID,
   return hitsCollection;
 }
 
+// GetAHCALHitsCollection method()
+//
+HGCALTBAHCALHitsCollection* HGCALTBEventAction::GetAHCALHitsCollection(G4int hcID,
+                                                                       const G4Event* event) const
+{
+  auto hitsCollection =
+    static_cast<HGCALTBAHCALHitsCollection*>(event->GetHCofThisEvent()->GetHC(hcID));
+
+  if (!hitsCollection) {
+    G4ExceptionDescription msg;
+    msg << "Cannot access hitsCollection ID " << hcID;
+    G4Exception("HGCALTBEventAction::GetHitsCollection()", "MyCode0003", FatalException, msg);
+  }
+
+  return hitsCollection;
+}
+
 void HGCALTBEventAction::EndOfEventAction(const G4Event* event)
 {
   // Access Event random seeds
@@ -106,7 +128,7 @@ void HGCALTBEventAction::EndOfEventAction(const G4Event* event)
   for (std::size_t i = 0; i < HGCALTBConstants::CEELayers; i++) {
     auto CEESignals = (*CEEHC)[i]->GetCEESignals();
     G4double CEELayerSignal = std::accumulate(CEESignals.begin(), CEESignals.end(), 0.);
-    fCEELayerSignals[i] = CEELayerSignal / HGCALTBConstants::MIPSilicon;
+    fCEELayerSignals[i] = CEELayerSignal / HGCALTBConstants::MIPSilicon;  // MIP calibration
   }
 
   // CHE Hits
@@ -118,19 +140,33 @@ void HGCALTBEventAction::EndOfEventAction(const G4Event* event)
   for (std::size_t i = 0; i < HGCALTBConstants::CHELayers; i++) {
     auto CHESignals = (*CHEHC)[i]->GetCHESignals();
     G4double CHELayerSignal = std::accumulate(CHESignals.begin(), CHESignals.end(), 0.);
-    fCHELayerSignals[i] = CHELayerSignal / HGCALTBConstants::MIPSilicon;
+    fCHELayerSignals[i] = CHELayerSignal / HGCALTBConstants::MIPSilicon;  // MIP calibration
+  }
+
+  // AHCAL Hits
+  //
+  auto AHCALHCID =
+    G4SDManager::GetSDMpointer()->GetCollectionID(HGCALTBAHCALSD::fAHCALHitsCollectionName);
+  HGCALTBAHCALHitsCollection* AHCALHC = GetAHCALHitsCollection(AHCALHCID, event);
+
+  for (std::size_t i = 0; i < HGCALTBConstants::AHCALLayers; i++) {
+    auto AHCALSignals = (*AHCALHC)[i]->GetAHSignals();
+    G4double AHCALLayerSignal = std::accumulate(AHCALSignals.begin(), AHCALSignals.end(), 0.);
+    fAHCALLayerSignals[i] = AHCALLayerSignal / HGCALTBConstants::MIPSilicon;  // MIP calibration
   }
 
   // Accumulate statistics
   //
   auto CEETot = std::accumulate(fCEELayerSignals.begin(), fCEELayerSignals.end(), 0.);
   auto CHETot = std::accumulate(fCHELayerSignals.begin(), fCHELayerSignals.end(), 0.);
-  auto HGCALTot = CEETot + CHETot;
+  auto AHCALTot = std::accumulate(fAHCALLayerSignals.begin(), fAHCALLayerSignals.end(), 0.);
+  auto HGCALTot = CEETot + CHETot + AHCALTot;
   auto analysisManager = G4AnalysisManager::Instance();
   analysisManager->FillNtupleDColumn(0, edep);
   analysisManager->FillNtupleDColumn(1, CEETot);
   analysisManager->FillNtupleDColumn(2, CHETot);
-  analysisManager->FillNtupleDColumn(3, HGCALTot);
+  analysisManager->FillNtupleDColumn(3, AHCALTot);
+  analysisManager->FillNtupleDColumn(4, HGCALTot);
   analysisManager->AddNtupleRow();
 }
 

--- a/src/HGCALTBRunAction.cc
+++ b/src/HGCALTBRunAction.cc
@@ -40,9 +40,11 @@ HGCALTBRunAction::HGCALTBRunAction(HGCALTBEventAction* eventAction)
   analysisManager->CreateNtupleDColumn("edep");
   analysisManager->CreateNtupleDColumn("CEETot");
   analysisManager->CreateNtupleDColumn("CHETot");
+  analysisManager->CreateNtupleDColumn("AHCALTot");
   analysisManager->CreateNtupleDColumn("HGCALTot");
   analysisManager->CreateNtupleDColumn("CEESignals", fEventAction->GetCEESignals());
   analysisManager->CreateNtupleDColumn("CHESignals", fEventAction->GetCHESignals());
+  analysisManager->CreateNtupleDColumn("AHCALSignals", fEventAction->GetAHCALSignals());
   analysisManager->FinishNtuple();
 }
 


### PR DESCRIPTION
Save signals from AHCAL in root output files. Apply the MIP calibration estimated with 200 GeV muons and cut over 0.5 MIP threshold for every tile.