### PR TITLE
Ass noise and Birks effect

### DIFF
--- a/include/HGCALTBAHCALSD.hh
+++ b/include/HGCALTBAHCALSD.hh
@@ -44,7 +44,16 @@ class HGCALTBAHCALSD : public G4VSensitiveDetector
   private:
     HGCALTBAHCALHitsCollection* fHitsCollection;
     inline G4int MapTileCpNo(G4int cpno) const;
+    inline G4double ApplyBirk(G4double edep, G4double stepl) const;
 };
+
+inline G4double HGCALTBAHCALSD::ApplyBirk(G4double edep, G4double stepl) const
+{
+  const G4double kBirk = 0.126;  // mm/MeV (to be confirmed)
+  G4double newe = ((edep / stepl) / (1. + kBirk * (edep / stepl))) * stepl;
+  if (newe > edep) newe = edep;
+  return newe;
+}
 
 inline G4int HGCALTBAHCALSD::MapTileCpNo(G4int cpno) const
 {

--- a/include/HGCALTBConstants.hh
+++ b/include/HGCALTBConstants.hh
@@ -34,6 +34,12 @@ constexpr G4int CEECellMaxCpNo = 2129;
 // CEE (small) silicon cells per big hexagon (layer)
 constexpr G4int CEECells = CEECellMaxCpNo - CEECellMinCpNo;  // 126
 
+// CEE Threshold
+constexpr G4double CEEThreshold = 0.5;  // MIP
+
+// CEE noise
+constexpr G4double CEENoiseSigma = 0.05;  // MIP
+
 // HGCALCHE constants
 //
 
@@ -64,7 +70,10 @@ constexpr G4int AHCALtileperlayer = AHCALrow * AHCALcolumn;
 constexpr G4int AHCALLayers = 39;
 
 // AHCAL MIP threshold
-constexpr G4double AHCALThreshold = 0.5;
+constexpr G4double AHCALThreshold = 0.5;  // MIP
+
+// AHCAL noise
+constexpr G4double AHCALNoiseSigma = 0.10;  // MIP
 
 // MIP calibration
 //

--- a/src/HGCALTBAHCALSD.cc
+++ b/src/HGCALTBAHCALSD.cc
@@ -74,7 +74,13 @@ G4bool HGCALTBAHCALSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
   // Access the corresponding hit
   //
   auto hit = (*fHitsCollection)[AHCALLayerID];
-  hit->AddTileEdep(TileID, aStep->GetTotalEnergyDeposit());
+  auto edep = aStep->GetTotalEnergyDeposit();
+  auto stepl = aStep->GetStepLength();
+  auto charge = aStep->GetTrack()->GetDynamicParticle()->GetDefinition()->GetPDGCharge();
+  if (stepl > 0. && charge != 0) {
+    edep = ApplyBirk(edep, stepl);
+  }
+  hit->AddTileEdep(TileID, edep);
 
   return true;
 }


### PR DESCRIPTION
Add electronic noise to every calorimeter subdetector and Birks Law to hit in AHCAL.