### PR TITLE
Fix bug in CHE hit handling

### DIFF
--- a/include/HGCALTBConstants.hh
+++ b/include/HGCALTBConstants.hh
@@ -46,6 +46,9 @@ constexpr G4double CEENoiseSigma = 0.05;  // MIP
 // CHE longitudinal layers
 constexpr G4int CHELayers = 12;
 
+// CHE longitudinal layers with 7 silicon wafers
+constexpr G4int CHESevenWaferLayers = 9;
+
 // CHE copynumbers for HGCalHECellCoarse (exluding HGCALHECellCoarseHalf)
 constexpr G4int CHECellMinCpNo = 2003;
 constexpr G4int CHECellMaxCpNo = 2129;

--- a/src/HGCALTBEventAction.cc
+++ b/src/HGCALTBEventAction.cc
@@ -151,8 +151,15 @@ void HGCALTBEventAction::EndOfEventAction(const G4Event* event)
 
   for (std::size_t i = 0; i < HGCALTBConstants::CHELayers; i++) {
     auto CHESignals = (*CHEHC)[i]->GetCHESignals();
-    G4double CHELayerSignal =
-      std::accumulate(CHESignals.begin(), CHESignals.end(), 0., ApplyHGCALCut);
+    G4double CHELayerSignal = 0.;
+    if (i < HGCALTBConstants::CHESevenWaferLayers) {
+      CHELayerSignal = std::accumulate(CHESignals.begin(), CHESignals.end(), 0., ApplyHGCALCut);
+    }
+    else {  // for last 3 CHE layers only add up cells for 1 silicon wafer
+      CHELayerSignal =
+        std::accumulate(CHESignals.begin(), CHESignals.begin() + (HGCALTBConstants::CEECells - 1),
+                        0., ApplyHGCALCut);
+    }
     fCHELayerSignals[i] = CHELayerSignal;
   }
 


### PR DESCRIPTION
At the end of the event limit the number of channels accumulated for the last three layers of CHE that have only one silicon wafer (instead of seven).