### PR TITLE
Tune simulation parameters

### DIFF
--- a/HGCALTB.cc
+++ b/HGCALTB.cc
@@ -38,6 +38,7 @@ void PrintHelp()
          << "  -u UISESSION    string of the Geant4 UI session to use\n"
          << "  -t THREADS      number of threads to use in the simulation\n"
          << "  -p PHYSICSLIST  string of the physics list to use\n"
+         << "  -f FILENAME     optional string with custom file name\n"
          << "  -h              print this help and exit\n"
          << G4endl;
 }
@@ -63,6 +64,7 @@ int main(int argc, char** argv)
   G4String macro;
   G4String session;
   G4String custom_pl = "FTFP_BERT";  // default physics list
+  G4String custom_filename = "";  // default file name selected by RunAction
 #ifdef G4MULTITHREADED
   G4int nThreads = G4Threading::G4GetNumberOfCores();
 #endif
@@ -75,6 +77,8 @@ int main(int argc, char** argv)
       session = argv[i + 1];
     else if (G4String(argv[i]) == "-p")
       custom_pl = argv[i + 1];
+    else if (G4String(argv[i]) == "-f")
+      custom_filename = argv[i + 1];
 #ifdef G4MULTITHREADED
     else if (G4String(argv[i]) == "-t") {
       nThreads = G4UIcommand::ConvertToInt(argv[i + 1]);
@@ -121,7 +125,7 @@ int main(int argc, char** argv)
 
   runManager->SetUserInitialization(new HGCALTBDetConstruction());
 
-  runManager->SetUserInitialization(new HGCALTBActInitialization());
+  runManager->SetUserInitialization(new HGCALTBActInitialization(custom_filename));
 
   // Visualization manager construction
   //

--- a/include/HGCALTBAHCALSD.hh
+++ b/include/HGCALTBAHCALSD.hh
@@ -44,30 +44,31 @@ class HGCALTBAHCALSD : public G4VSensitiveDetector
   private:
     HGCALTBAHCALHitsCollection* fHitsCollection;
     inline G4int MapTileCpNo(G4int cpno) const;
-    inline G4double ApplyBirk(const G4Step* aStep) const;
+    inline G4double GetBirk(const G4Step* aStep) const;
 };
 
-inline G4double HGCALTBAHCALSD::ApplyBirk(const G4Step* aStep) const
+inline G4double HGCALTBAHCALSD::GetBirk(const G4Step* const aStep) const
 {
   // from https://github.com/cms-sw/cmssw/blob/master/SimG4CMS/Calo/src/CaloSD.cc#L727
   double weight = 1.;
   double charge = aStep->GetPreStepPoint()->GetCharge();
   double length = aStep->GetStepLength();
-  double edep = aStep->GetTotalEnergyDeposit();
   double birk1 = 0.0052;
   double birk2 = 0.142;
   double birk3 = 1.75;
 
   if (charge != 0. && length > 0.) {
-    double density = aStep->GetPreStepPoint()->GetMaterial()->GetDensity();
+    double density = aStep->GetPreStepPoint()->GetMaterial()->GetDensity() / (g / cm3);
     double dedx = aStep->GetTotalEnergyDeposit() / length;
     double rkb = birk1 / density;
     double c = birk2 * rkb * rkb;
-    if (std::abs(charge) >= 2.) rkb /= birk3;  // based on alpha particle data
+    if (std::abs(charge) >= 2.) {
+      rkb /= birk3;
+    }  // based on alpha particle data
     weight = 1. / (1. + rkb * dedx + c * dedx * dedx);
   }
 
-  return edep * weight;
+  return weight;
 }
 
 inline G4int HGCALTBAHCALSD::MapTileCpNo(G4int cpno) const

--- a/include/HGCALTBAHCALSD.hh
+++ b/include/HGCALTBAHCALSD.hh
@@ -44,15 +44,30 @@ class HGCALTBAHCALSD : public G4VSensitiveDetector
   private:
     HGCALTBAHCALHitsCollection* fHitsCollection;
     inline G4int MapTileCpNo(G4int cpno) const;
-    inline G4double ApplyBirk(G4double edep, G4double stepl) const;
+    inline G4double ApplyBirk(const G4Step* aStep) const;
 };
 
-inline G4double HGCALTBAHCALSD::ApplyBirk(G4double edep, G4double stepl) const
+inline G4double HGCALTBAHCALSD::ApplyBirk(const G4Step* aStep) const
 {
-  const G4double kBirk = 0.126;  // mm/MeV (to be confirmed)
-  G4double newe = ((edep / stepl) / (1. + kBirk * (edep / stepl))) * stepl;
-  if (newe > edep) newe = edep;
-  return newe;
+  // from https://github.com/cms-sw/cmssw/blob/master/SimG4CMS/Calo/src/CaloSD.cc#L727
+  double weight = 1.;
+  double charge = aStep->GetPreStepPoint()->GetCharge();
+  double length = aStep->GetStepLength();
+  double edep = aStep->GetTotalEnergyDeposit();
+  double birk1 = 0.0052;
+  double birk2 = 0.142;
+  double birk3 = 1.75;
+
+  if (charge != 0. && length > 0.) {
+    double density = aStep->GetPreStepPoint()->GetMaterial()->GetDensity();
+    double dedx = aStep->GetTotalEnergyDeposit() / length;
+    double rkb = birk1 / density;
+    double c = birk2 * rkb * rkb;
+    if (std::abs(charge) >= 2.) rkb /= birk3;  // based on alpha particle data
+    weight = 1. / (1. + rkb * dedx + c * dedx * dedx);
+  }
+
+  return edep * weight;
 }
 
 inline G4int HGCALTBAHCALSD::MapTileCpNo(G4int cpno) const

--- a/include/HGCALTBActInitialization.hh
+++ b/include/HGCALTBActInitialization.hh
@@ -12,16 +12,20 @@
 
 // Includers from Geant4
 //
+#  include "G4String.hh"
 #  include "G4VUserActionInitialization.hh"
 
 class HGCALTBActInitialization : public G4VUserActionInitialization
 {
   public:
-    HGCALTBActInitialization();
+    HGCALTBActInitialization(G4String filename);
     virtual ~HGCALTBActInitialization();
     // vitual methods from base class
     virtual void BuildForMaster() const;
     virtual void Build() const;
+
+  private:
+    G4String fFileName;
 };
 
 #endif  // HGCALTBActInitialization_h

--- a/include/HGCALTBConstants.hh
+++ b/include/HGCALTBConstants.hh
@@ -41,7 +41,8 @@ constexpr G4int CEECells = CEECellMaxCpNo - CEECellMinCpNo;  // 126
 constexpr G4double CEEThreshold = 0.5;  // MIP
 
 // CEE noise
-constexpr G4double CEENoiseSigma = 0.05;  // MIP
+// intrinsic noise - https://arxiv.org/pdf/2012.06336.pdf fig. 22
+constexpr G4double CEENoiseSigma = 0.12;  // MIP
 
 // HGCALCHE constants
 //

--- a/include/HGCALTBConstants.hh
+++ b/include/HGCALTBConstants.hh
@@ -21,6 +21,9 @@
 namespace HGCALTBConstants
 {
 
+// Time cut
+constexpr G4double TimeCut = 500.;  // ns
+
 // HGCALCEE constants
 //
 

--- a/include/HGCALTBRunAction.hh
+++ b/include/HGCALTBRunAction.hh
@@ -25,7 +25,7 @@ class G4Run;
 class HGCALTBRunAction : public G4UserRunAction
 {
   public:
-    HGCALTBRunAction(HGCALTBEventAction* eventAction);
+    HGCALTBRunAction(HGCALTBEventAction* eventAction, G4String filename);
     virtual ~HGCALTBRunAction();
     // virtual methods from base class
     virtual void BeginOfRunAction(const G4Run*);
@@ -33,6 +33,7 @@ class HGCALTBRunAction : public G4UserRunAction
 
   private:
     HGCALTBEventAction* fEventAction;
+    G4String fFileName;
 };
 
 #endif  // HGCALTBRunAction_h 1

--- a/src/HGCALTBAHCALSD.cc
+++ b/src/HGCALTBAHCALSD.cc
@@ -57,6 +57,10 @@ void HGCALTBAHCALSD::Initialize(G4HCofThisEvent* hce)
 //
 G4bool HGCALTBAHCALSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
 {
+  // Apply time cut
+  //
+  if (aStep->GetTrack()->GetGlobalTime() > HGCALTBConstants::TimeCut) return false;
+
   // Get CHE layer ID
   //
   auto AHCALLayerID = aStep->GetPreStepPoint()->GetTouchableHandle()->GetCopyNumber(1) - 1;

--- a/src/HGCALTBAHCALSD.cc
+++ b/src/HGCALTBAHCALSD.cc
@@ -74,11 +74,11 @@ G4bool HGCALTBAHCALSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
   // Access the corresponding hit
   //
   auto hit = (*fHitsCollection)[AHCALLayerID];
-  auto edep = aStep->GetTotalEnergyDeposit();
   auto stepl = aStep->GetStepLength();
   auto charge = aStep->GetTrack()->GetDynamicParticle()->GetDefinition()->GetPDGCharge();
+  auto edep = aStep->GetTotalEnergyDeposit();
   if (stepl > 0. && charge != 0) {
-    edep = ApplyBirk(edep, stepl);
+    edep = ApplyBirk(aStep);
   }
   hit->AddTileEdep(TileID, edep);
 

--- a/src/HGCALTBAHCALSD.cc
+++ b/src/HGCALTBAHCALSD.cc
@@ -78,7 +78,7 @@ G4bool HGCALTBAHCALSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
   auto charge = aStep->GetTrack()->GetDynamicParticle()->GetDefinition()->GetPDGCharge();
   auto edep = aStep->GetTotalEnergyDeposit();
   if (stepl > 0. && charge != 0) {
-    edep = ApplyBirk(aStep);
+    edep *= GetBirk(aStep);
   }
   hit->AddTileEdep(TileID, edep);
 

--- a/src/HGCALTBActInitialization.cc
+++ b/src/HGCALTBActInitialization.cc
@@ -19,7 +19,9 @@
 
 // Constructor and de-constructor
 //
-HGCALTBActInitialization::HGCALTBActInitialization() : G4VUserActionInitialization() {}
+HGCALTBActInitialization::HGCALTBActInitialization(G4String filename)
+  : G4VUserActionInitialization(), fFileName(filename)
+{}
 
 HGCALTBActInitialization::~HGCALTBActInitialization() {}
 
@@ -28,7 +30,7 @@ HGCALTBActInitialization::~HGCALTBActInitialization() {}
 void HGCALTBActInitialization::BuildForMaster() const
 {
   auto EventAction = new HGCALTBEventAction();
-  SetUserAction(new HGCALTBRunAction(EventAction));
+  SetUserAction(new HGCALTBRunAction(EventAction, fFileName));
 }
 
 void HGCALTBActInitialization::Build() const
@@ -37,7 +39,7 @@ void HGCALTBActInitialization::Build() const
   auto EventAction = new HGCALTBEventAction();
   SetUserAction(PrimaryGenAction);
   SetUserAction(new HGCALTBStepAction(EventAction));
-  SetUserAction(new HGCALTBRunAction(EventAction));
+  SetUserAction(new HGCALTBRunAction(EventAction, fFileName));
   SetUserAction(EventAction);
   SetUserAction(new HGCALTBTrackAction(EventAction));
 }

--- a/src/HGCALTBCEESD.cc
+++ b/src/HGCALTBCEESD.cc
@@ -59,6 +59,10 @@ void HGCALTBCEESD::Initialize(G4HCofThisEvent* hce)
 //
 G4bool HGCALTBCEESD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
 {
+  // Apply time cut
+  //
+  if (aStep->GetTrack()->GetGlobalTime() > HGCALTBConstants::TimeCut) return false;
+
   // Get CEE layer ID
   //
   auto CEELayerID = (aStep->GetPreStepPoint()->GetTouchableHandle()->GetCopyNumber(2) - 1) / 3;

--- a/src/HGCALTBCHESD.cc
+++ b/src/HGCALTBCHESD.cc
@@ -61,6 +61,10 @@ void HGCALTBCHESD::Initialize(G4HCofThisEvent* hce)
 //
 G4bool HGCALTBCHESD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
 {
+  // Apply time cut
+  //
+  if (aStep->GetTrack()->GetGlobalTime() > HGCALTBConstants::TimeCut) return false;
+
   // Get CHE layer ID
   //
   auto CHELayerID = (aStep->GetPreStepPoint()->GetTouchableHandle()->GetCopyNumber(2) - 1) / 3;

--- a/src/HGCALTBRunAction.cc
+++ b/src/HGCALTBRunAction.cc
@@ -26,8 +26,8 @@
 
 // Constructor and de-constructor
 //
-HGCALTBRunAction::HGCALTBRunAction(HGCALTBEventAction* eventAction)
-  : G4UserRunAction(), fEventAction(eventAction)
+HGCALTBRunAction::HGCALTBRunAction(HGCALTBEventAction* eventAction, G4String filename)
+  : G4UserRunAction(), fEventAction(eventAction), fFileName(filename)
 {
   G4RunManager::GetRunManager()->SetPrintProgress(1);  // print each event number
 
@@ -71,9 +71,16 @@ void HGCALTBRunAction::BeginOfRunAction(const G4Run* Run)
   // G4RunManager::GetRunManager()->SetRandomNumberStore( true );
 
   auto analysisManager = G4AnalysisManager::Instance();
+  G4String outputfile;
 
-  std::string runnumber = std::to_string(Run->GetRunID());
-  G4String outputfile = "HGCALTBout_Run" + runnumber + ".root";
+  if (fFileName.empty()) {
+    std::string runnumber = std::to_string(Run->GetRunID());
+    outputfile = "HGCALTBout_Run" + runnumber + ".root";
+  }
+  else {
+    outputfile = fFileName;
+  }
+
   analysisManager->OpenFile(outputfile);
 }
 


### PR DESCRIPTION
Tune simulation parameters as in cms-sw:
- Use the same Birks Law implementation as cms-sw for hit in AHCAL bb2c629318b8f2fe2cf3548e82f2a196a5c2dadb b3558a240198c82d55852276c4ab7194c96bea77
- Add time cut for hit collections b3558a240198c82d55852276c4ab7194c96bea77
- Tune silicon cells Gaussian sigma noise e759346aec7ef103cba73adac291aeeb661e6b08

Add the possibility to specify in the main() parser the output file name be6dec4358bbd1a21d4ed42253a5bf3bc1ec9ce9