### PR TITLE
Example AdePT integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,12 @@ else()
   find_package(Geant4 REQUIRED)
 endif()
 
+if(USE_ADEPT)
+  # Find AdePT
+  find_package(AdePT)
+  add_compile_definitions(USE_ADEPT)
+endif()
+
 #----------------------------------------------------------------------------
 # Output pedantic warnings
 #
@@ -44,15 +50,26 @@ include(${Geant4_USE_FILE})
 #
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include
                     ${Geant4_INCLUDE_DIR}
-		    ${FLUKAInterface_INCLUDE_DIR})
+                    ${FLUKAInterface_INCLUDE_DIR})
+if(USE_ADEPT)
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/adept_integration/include ${AdePT_INCLUDE_DIRS})
+endif()
+
 file(GLOB sources ${PROJECT_SOURCE_DIR}/src/*.cc)
 file(GLOB headers ${PROJECT_SOURCE_DIR}/include/*.hh)
+if(USE_ADEPT)
+  list(APPEND sources ${PROJECT_SOURCE_DIR}/adept_integration/src/FTFP_BERT_AdePT.cc)
+  list(APPEND headers ${PROJECT_SOURCE_DIR}/adept_integration/include/FTFP_BERT_AdePT.hh)
+endif()
 
 #----------------------------------------------------------------------------
 # Add the executable, and link it to the Geant4 libraries
 #
 add_executable(HGCALTB HGCALTB.cc ${sources} ${headers})
 target_link_libraries(HGCALTB ${Geant4_LIBRARIES} ${FLUKAInterface_LIBRARIES})
+if(USE_ADEPT)
+  target_link_libraries(HGCALTB ${AdePT_LIBRARIES})
+endif()
 set_target_properties(HGCALTB PROPERTIES CXX_STANDARD 17)
 
 #----------------------------------------------------------------------------
@@ -68,6 +85,9 @@ set(HGCALTB_SCRIPTS
     HGCALTBrun.mac
     HGCALTBfullrun.mac
   )
+if(USE_ADEPT)
+list(APPEND HGCALTB_SCRIPTS HGCALTBrun_adept.mac HGCALTBfullrun_adept.mac)
+endif()
 
 foreach(_script ${HGCALTB_SCRIPTS})
   configure_file(

--- a/HGCALTB.cc
+++ b/HGCALTB.cc
@@ -27,6 +27,10 @@
 #include "G4Version.hh"
 #include "G4VisExecutive.hh"
 
+#ifdef USE_ADEPT
+#include "FTFP_BERT_AdePT.hh"
+#endif
+
 // CLI string outputs
 namespace CLIOutputs
 {
@@ -68,6 +72,9 @@ int main(int argc, char** argv)
 #ifdef G4MULTITHREADED
   G4int nThreads = G4Threading::G4GetNumberOfCores();
 #endif
+#ifdef USE_ADEPT
+  G4bool adept{false};
+#endif
 
   // CLI parsing
   for (G4int i = 1; i < argc; i = i + 2) {
@@ -82,6 +89,12 @@ int main(int argc, char** argv)
 #ifdef G4MULTITHREADED
     else if (G4String(argv[i]) == "-t") {
       nThreads = G4UIcommand::ConvertToInt(argv[i + 1]);
+    }
+#endif
+#ifdef USE_ADEPT
+    else if (G4String(argv[i]) == "--adept") {
+      adept = true;
+      i-=1;
     }
 #endif
     else if (G4String(argv[i]) == "-h") {
@@ -120,7 +133,15 @@ int main(int argc, char** argv)
     PrintPLFactoryUsageError::PLFactoryUsageError();
     return 1;
   }
-  auto physicsList = physListFactory->GetReferencePhysList(custom_pl);
+  G4VUserPhysicsList *physicsList;
+  #ifndef USE_ADEPT
+    physicsList = physListFactory->GetReferencePhysList(custom_pl);
+  #else
+    if(adept)
+      physicsList = new FTFP_BERT_AdePT();
+    else
+      physicsList = physListFactory->GetReferencePhysList(custom_pl);
+  #endif
   runManager->SetUserInitialization(physicsList);
 
   runManager->SetUserInitialization(new HGCALTBDetConstruction());

--- a/HGCALTBfullrun_adept.mac
+++ b/HGCALTBfullrun_adept.mac
@@ -1,0 +1,42 @@
+# Temporary workaround since we don't have a G4 to VecGeom converter
+/adept/setVecGeomGDML TBHGCal181Oct.gdml
+/adept/setVerbosity 0
+## Threshold for buffering tracks before sending to GPU
+/adept/setTransportBufferThreshold 2000
+## Total number of GPU track slots (not per thread)
+/adept/setMillionsOfTrackSlots 8
+/adept/setMillionsOfHitSlots 2
+
+/adept/setTrackInAllRegions true
+#/adept/addGPURegion HGCalRegion
+#/adept/addGPURegion HGCalAHcalRegion
+
+/process/em/verbose 0
+/process/had/verbose 0
+/run/initialize
+/run/printProgress 100
+/gun/particle pi-
+# Run0
+/gun/energy 20 GeV
+/run/beamOn 10000
+# Run1
+/gun/energy 50 GeV
+/run/beamOn 10000
+# Run2
+/gun/energy 80 GeV
+/run/beamOn 10000
+# Run3
+/gun/energy 100 GeV
+/run/beamOn 10000
+# Run4
+/gun/energy 120 GeV
+/run/beamOn 10000
+# Run5
+/gun/energy 200 GeV
+/run/beamOn 10000
+# Run6
+/gun/energy 250 GeV
+/run/beamOn 10000
+# Run7
+/gun/energy 300 GeV
+/run/beamOn 10000

--- a/HGCALTBrun_adept.mac
+++ b/HGCALTBrun_adept.mac
@@ -1,0 +1,19 @@
+/adept/setVecGeomGDML TBHGCal181Oct.gdml
+/adept/setVerbosity 0
+## Threshold for buffering tracks before sending to GPU
+/adept/setTransportBufferThreshold 2000
+## Total number of GPU track slots (not per thread)
+/adept/setMillionsOfTrackSlots 8
+/adept/setMillionsOfHitSlots 2
+
+/adept/setTrackInAllRegions true
+#/adept/addGPURegion HGCalRegion
+#/adept/addGPURegion HGCalAHcalRegion
+
+/process/em/verbose 0
+/process/had/verbose 0
+/run/initialize
+/run/printProgress 100
+/gun/particle pi-
+/gun/energy 10 GeV
+/run/beamOn 1000

--- a/HGCALTBrun_adept.mac
+++ b/HGCALTBrun_adept.mac
@@ -2,9 +2,11 @@
 /adept/setVerbosity 0
 ## Threshold for buffering tracks before sending to GPU
 /adept/setTransportBufferThreshold 2000
-## Total number of GPU track slots (not per thread)
-/adept/setMillionsOfTrackSlots 8
-/adept/setMillionsOfHitSlots 2
+## These numbers determine the amount of memory allocated in the GPU for 
+## track and hit buffers. They should be adjusted according to the number of CPU 
+## threads we want to run, and the memory available in the device
+/adept/setMillionsOfTrackSlots 4
+/adept/setMillionsOfHitSlots 1
 
 /adept/setTrackInAllRegions true
 #/adept/addGPURegion HGCalRegion

--- a/adept_integration/include/FTFP_BERT_AdePT.hh
+++ b/adept_integration/include/FTFP_BERT_AdePT.hh
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2023 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef FTFP_BERT_AdePT_h
+#define FTFP_BERT_AdePT_h 1
+
+#include <CLHEP/Units/SystemOfUnits.h>
+
+#include "globals.hh"
+#include "G4VModularPhysicsList.hh"
+#include <AdePT/integration/AdePTTrackingManager.hh>
+#include <AdePT/integration/AdePTPhysics.hh>
+
+class FTFP_BERT_AdePT : public G4VModularPhysicsList {
+public:
+  FTFP_BERT_AdePT(G4int ver = 1);
+  virtual ~FTFP_BERT_AdePT() = default;
+
+  FTFP_BERT_AdePT(const FTFP_BERT_AdePT &) = delete;
+  FTFP_BERT_AdePT &operator=(const FTFP_BERT_AdePT &) = delete;
+};
+
+#endif

--- a/adept_integration/src/FTFP_BERT_AdePT.cc
+++ b/adept_integration/src/FTFP_BERT_AdePT.cc
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2022 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#include <iomanip>
+
+#include "globals.hh"
+#include "G4ios.hh"
+#include "G4ProcessManager.hh"
+#include "G4ProcessVector.hh"
+#include "G4ParticleTypes.hh"
+#include "G4ParticleTable.hh"
+
+#include "G4Material.hh"
+#include "G4MaterialTable.hh"
+
+#include "G4DecayPhysics.hh"
+#include "G4EmStandardPhysics.hh"
+#include "G4EmExtraPhysics.hh"
+#include "G4IonPhysics.hh"
+#include "G4StoppingPhysics.hh"
+#include "G4HadronElasticPhysics.hh"
+#include "G4NeutronTrackingCut.hh"
+#include "G4HadronPhysicsFTFP_BERT.hh"
+
+#include <AdePT/integration/HepEMPhysics.hh>
+#include <AdePT/integration/AdePTPhysics.hh>
+#include "FTFP_BERT_AdePT.hh"
+
+FTFP_BERT_AdePT::FTFP_BERT_AdePT(G4int ver)
+{
+  // default cut value  (1.0mm)
+  // defaultCutValue = 1.0*CLHEP::mm;
+  G4cout << "<<< Geant4 Physics List simulation engine: FTFP_BERT_AdePT" << G4endl;
+  G4cout << G4endl;
+  defaultCutValue = 0.7 * CLHEP::mm;
+  SetVerboseLevel(ver);
+
+  // EM Physics
+
+  // Register the EM physics to use for tracking on CPU
+  // RegisterPhysics(new G4EmStandardPhysics());
+  RegisterPhysics(new HepEMPhysics());
+
+  // Register the AdePT physics
+  RegisterPhysics(new AdePTPhysics());
+
+  // Synchroton Radiation & GN Physics
+  // comenting out to remove gamma- and lepto-nuclear processes
+  // RegisterPhysics( new G4EmExtraPhysics(ver) );
+
+  // Decays
+  RegisterPhysics(new G4DecayPhysics(ver));
+
+  // Hadron Elastic scattering
+  RegisterPhysics(new G4HadronElasticPhysics(ver));
+
+  // Hadron Physics
+  RegisterPhysics(new G4HadronPhysicsFTFP_BERT(ver));
+
+  // Stopping Physics
+  RegisterPhysics(new G4StoppingPhysics(ver));
+
+  // Ion Physics
+  RegisterPhysics(new G4IonPhysics(ver));
+
+  // Neutron tracking cut
+  RegisterPhysics(new G4NeutronTrackingCut(ver));
+}

--- a/include/HGCALTBRunAction.hh
+++ b/include/HGCALTBRunAction.hh
@@ -14,6 +14,7 @@
 // Includers from Geant4
 //
 #  include "G4UserRunAction.hh"
+#  include "G4Timer.hh"
 #  include "globals.hh"
 
 // Includers from project files
@@ -34,6 +35,9 @@ class HGCALTBRunAction : public G4UserRunAction
   private:
     HGCALTBEventAction* fEventAction;
     G4String fFileName;
+#ifdef USE_ADEPT
+    G4Timer fTimer;
+#endif
 };
 
 #endif  // HGCALTBRunAction_h 1

--- a/src/HGCALTBDetConstruction.cc
+++ b/src/HGCALTBDetConstruction.cc
@@ -24,6 +24,11 @@
 #include "G4SDManager.hh"
 #include "G4VisAttributes.hh"
 
+#include "G4Region.hh"
+#include "G4RegionStore.hh"
+#include "G4ProductionCuts.hh"
+#include "G4ProductionCutsTable.hh"
+
 // Includers from std
 //
 #include <string>

--- a/src/HGCALTBRunAction.cc
+++ b/src/HGCALTBRunAction.cc
@@ -82,10 +82,23 @@ void HGCALTBRunAction::BeginOfRunAction(const G4Run* Run)
   }
 
   analysisManager->OpenFile(outputfile);
+
+  // If using AdePT we may be interested in comparing the execution time
+#ifdef USE_ADEPT
+  fTimer.Start();
+#endif
 }
 
 void HGCALTBRunAction::EndOfRunAction(const G4Run*)
 {
+#ifdef USE_ADEPT
+  if(G4Threading::G4GetThreadId() < 0)
+  {
+    fTimer.Stop();
+    G4cout << "Run time: " << fTimer.GetRealElapsed() << "\n";
+  }
+#endif
+
   auto analysisManager = G4AnalysisManager::Instance();
 
   analysisManager->Write();


### PR DESCRIPTION
This PR showcases how to integrate AdePT into this application.

The main changes are:

- Linking the executable against the AdePT libraries
- Adding a custom  `G4VModularPhysicsList` which registers the AdePT physics constructor (In case of applications already using a modular physics lists we would only have to add the AdePT physics)

In addition, we include timers, a command-line switch to activate AdePT, and a macro file for the AdePT run.

The reason to provide a separate macro is that we are able to easily modify several configuration options through it. However, AdePT can also be configured without using a Geant4 messenger.